### PR TITLE
Better UX for discovering checkpoints

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -9,7 +9,7 @@ import lightning as L
 import torch
 
 from lit_stablelm import StableLM, Tokenizer, Config
-from lit_stablelm.utils import EmptyInitOnDevice, lazy_load
+from lit_stablelm.utils import EmptyInitOnDevice, lazy_load, check_valid_checkpoint_dir
 
 
 @torch.no_grad()
@@ -85,12 +85,7 @@ def main(
             ``"llm.int8"``: LLM.int8() mode,
             ``"gptq.int4"``: GPTQ 4-bit mode.
     """
-    if not checkpoint_dir.is_dir():
-        raise OSError(
-            f"`--checkpoint_dir={str(checkpoint_dir)!r} must be a directory with the lit model checkpoint and"
-            " configurations. Please, follow the instructions at"
-            " https://github.com/Lightning-AI/lit-stablelm/blob/main/howto/download_weights.md"
-        )
+    check_valid_checkpoint_dir(checkpoint_dir)
 
     with open(checkpoint_dir / "lit_config.json") as fp:
         config = Config(**json.load(fp))

--- a/generate.py
+++ b/generate.py
@@ -9,7 +9,7 @@ import lightning as L
 import torch
 
 from lit_stablelm import StableLM, Tokenizer, Config
-from lit_stablelm.utils import EmptyInitOnDevice, lazy_load
+from lit_stablelm.utils import EmptyInitOnDevice, lazy_load, check_valid_checkpoint_dir
 
 
 @torch.no_grad()
@@ -95,12 +95,7 @@ def main(
             ``"llm.int8"``: LLM.int8() mode,
             ``"gptq.int4"``: GPTQ 4-bit mode.
     """
-    if not checkpoint_dir.is_dir():
-        raise OSError(
-            f"`--checkpoint_dir={str(checkpoint_dir)!r} must be a directory with the lit model checkpoint and"
-            " configurations. Please, follow the instructions at"
-            " https://github.com/Lightning-AI/lit-stablelm/blob/main/howto/download_weights.md"
-        )
+    check_valid_checkpoint_dir(checkpoint_dir)
 
     with open(checkpoint_dir / "lit_config.json") as fp:
         config = Config(**json.load(fp))

--- a/scripts/convert_hf_checkpoint.py
+++ b/scripts/convert_hf_checkpoint.py
@@ -12,30 +12,30 @@ wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
 from lit_stablelm.model import StableLM
-from lit_stablelm.utils import EmptyInitOnDevice
+from lit_stablelm.utils import EmptyInitOnDevice, check_valid_checkpoint_dir
 
 
 def copy_weights(state_dict, hf_weights, dtype=torch.float32):
     weight_map = {
         "gpt_neox.embed_in.weight": "transformer.wte.weight",
-        'gpt_neox.layers.{}.input_layernorm.bias': "transformer.h.{}.norm_1.bias",
-        'gpt_neox.layers.{}.input_layernorm.weight': "transformer.h.{}.norm_1.weight",
-        'gpt_neox.layers.{}.attention.query_key_value.bias': "transformer.h.{}.attn.attn.bias",
-        'gpt_neox.layers.{}.attention.query_key_value.weight': "transformer.h.{}.attn.attn.weight",
-        'gpt_neox.layers.{}.attention.dense.bias': "transformer.h.{}.attn.proj.bias",
-        'gpt_neox.layers.{}.attention.dense.weight': "transformer.h.{}.attn.proj.weight",
-        'gpt_neox.layers.{}.attention.rotary_emb.inv_freq': None,
-        'gpt_neox.layers.{}.attention.bias': None,
-        'gpt_neox.layers.{}.attention.masked_bias': None,
-        'gpt_neox.layers.{}.post_attention_layernorm.bias': "transformer.h.{}.norm_2.bias",
-        'gpt_neox.layers.{}.post_attention_layernorm.weight': "transformer.h.{}.norm_2.weight",
-        'gpt_neox.layers.{}.mlp.dense_h_to_4h.bias': "transformer.h.{}.mlp.fc.bias",
-        'gpt_neox.layers.{}.mlp.dense_h_to_4h.weight': "transformer.h.{}.mlp.fc.weight",
-        'gpt_neox.layers.{}.mlp.dense_4h_to_h.bias': "transformer.h.{}.mlp.proj.bias",
-        'gpt_neox.layers.{}.mlp.dense_4h_to_h.weight': "transformer.h.{}.mlp.proj.weight",
-        'gpt_neox.final_layer_norm.bias': "transformer.ln_f.bias",
-        'gpt_neox.final_layer_norm.weight': "transformer.ln_f.weight",
-        'embed_out.weight': "lm_head.weight",
+        "gpt_neox.layers.{}.input_layernorm.bias": "transformer.h.{}.norm_1.bias",
+        "gpt_neox.layers.{}.input_layernorm.weight": "transformer.h.{}.norm_1.weight",
+        "gpt_neox.layers.{}.attention.query_key_value.bias": "transformer.h.{}.attn.attn.bias",
+        "gpt_neox.layers.{}.attention.query_key_value.weight": "transformer.h.{}.attn.attn.weight",
+        "gpt_neox.layers.{}.attention.dense.bias": "transformer.h.{}.attn.proj.bias",
+        "gpt_neox.layers.{}.attention.dense.weight": "transformer.h.{}.attn.proj.weight",
+        "gpt_neox.layers.{}.attention.rotary_emb.inv_freq": None,
+        "gpt_neox.layers.{}.attention.bias": None,
+        "gpt_neox.layers.{}.attention.masked_bias": None,
+        "gpt_neox.layers.{}.post_attention_layernorm.bias": "transformer.h.{}.norm_2.bias",
+        "gpt_neox.layers.{}.post_attention_layernorm.weight": "transformer.h.{}.norm_2.weight",
+        "gpt_neox.layers.{}.mlp.dense_h_to_4h.bias": "transformer.h.{}.mlp.fc.bias",
+        "gpt_neox.layers.{}.mlp.dense_h_to_4h.weight": "transformer.h.{}.mlp.fc.weight",
+        "gpt_neox.layers.{}.mlp.dense_4h_to_h.bias": "transformer.h.{}.mlp.proj.bias",
+        "gpt_neox.layers.{}.mlp.dense_4h_to_h.weight": "transformer.h.{}.mlp.proj.weight",
+        "gpt_neox.final_layer_norm.bias": "transformer.ln_f.bias",
+        "gpt_neox.final_layer_norm.weight": "transformer.ln_f.weight",
+        "embed_out.weight": "lm_head.weight",
     }
 
     for name, param in hf_weights.items():
@@ -62,12 +62,7 @@ def convert_hf_checkpoint(
     model_name: Optional[str] = None,
     dtype: str = "float32",
 ) -> None:
-    if not checkpoint_dir.is_dir():
-        raise OSError(
-            f"`--checkpoint_dir={str(checkpoint_dir)!r} must be a directory."
-            " Please, follow the instructions at"
-            " https://github.com/Lightning-AI/lit-stablelm/blob/main/howto/download_weights.md"
-        )
+    check_valid_checkpoint_dir(checkpoint_dir)
 
     dt = getattr(torch, dtype, None)
     if not isinstance(dt, torch.dtype):
@@ -102,4 +97,3 @@ if __name__ == "__main__":
     from jsonargparse import CLI
 
     CLI(convert_hf_checkpoint)
-


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lit-stablelm/issues/9

Example message:

```bash
$ python generate.py --checkpoint_dir dir/that/doesnt/exist
Traceback (most recent call last):
  File "/home/carmocca/git/lit-stablelm/generate.py", line 153, in <module>
    CLI(main)
  File "/home/carmocca/git/nightly-venv/lib/python3.10/site-packages/jsonargparse/cli.py", line 82, in CLI
    return _run_component(component, cfg_init)
  File "/home/carmocca/git/nightly-venv/lib/python3.10/site-packages/jsonargparse/cli.py", line 147, in _run_component
    return component(**cfg)
  File "/home/carmocca/git/lit-stablelm/generate.py", line 98, in main
    check_valid_checkpoint_dir(checkpoint_dir)
  File "/home/carmocca/git/lit-stablelm/lit_stablelm/utils.py", line 294, in check_valid_checkpoint_dir
    raise OSError(message)
OSError: `--checkpoint_dir 'dir/that/doesnt/exist' is not a valid checkpoint directory. It must contain the files: 'lit_model.pth', 'lit_config.json', 'tokenizer.json' and 'tokenizer_config.json'.

Please, follow the instructions at https://github.com/Lightning-AI/lit-stablelm/blob/main/howto/download_weights.md

You have downloaded locally:
 --checkpoint_dir '/home/carmocca/git/lit-stablelm/checkpoints/EleutherAI/pythia-70m'
 --checkpoint_dir '/home/carmocca/git/lit-stablelm/checkpoints/togethercomputer/RedPajama-INCITE-Chat-3B-v1'
 --checkpoint_dir '/home/carmocca/git/lit-stablelm/checkpoints/togethercomputer/RedPajama-INCITE-Instruct-3B-v1'
 --checkpoint_dir '/home/carmocca/git/lit-stablelm/checkpoints/togethercomputer/RedPajama-INCITE-Base-3B-v1'
 --checkpoint_dir '/home/carmocca/git/lit-stablelm/checkpoints/stabilityai/stablelm-tuned-alpha-3b'
 --checkpoint_dir '/home/carmocca/git/lit-stablelm/checkpoints/stabilityai/stablelm-base-alpha-3b'

You can download:
 * stablelm-base-alpha-7b
 * stablelm-tuned-alpha-7b
 * pythia-160m
 * pythia-410m
 * pythia-1b
 * pythia-1.4b
 * pythia-2.8b
 * pythia-6.9b
 * pythia-12b
 * pythia-70m-deduped
 * pythia-160m-deduped
 * pythia-410m-deduped
 * pythia-1b-deduped
 * pythia-1.4b-deduped
 * pythia-2.8b-deduped
 * pythia-6.9b-deduped
 * pythia-12b-deduped
 * RedPajama-INCITE-Base-7B-v0.1
 * RedPajama-INCITE-Chat-7B-v0.1
 * RedPajama-INCITE-Instruct-7B-v0.1
```